### PR TITLE
Changes in camera example to omit some type casting

### DIFF
--- a/examples/2d-camera.nelua
+++ b/examples/2d-camera.nelua
@@ -12,16 +12,16 @@ require 'raylib'
 local MAX_BUILDINGS <comptime> = 100
 
 -- [[ Initialization [[
-local screenWidth <const> = 800_i32
-local screenHeight <const> = 450_i32
+local screenWidth <comptime> = 800
+local screenHeight <comptime> = 450
 
 
 Raylib.InitWindow(screenWidth, screenHeight, "raylib [core] example - 2d camera")
-local player = (@Rectangle){400, 280, 40, 40}
+local player: Rectangle = {400, 280, 40, 40}
 local buildings: Rectangle[MAX_BUILDINGS] = {}
 local buildColors: Color[MAX_BUILDINGS] = {}
 
-local spacing = 0_i32
+local spacing: float32 = 0
 
 for i = 0, < MAX_BUILDINGS do
    buildings[i].width  = Raylib.GetRandomValue(50, 200)
@@ -29,16 +29,21 @@ for i = 0, < MAX_BUILDINGS do
    buildings[i].y = screenHeight - 130 - buildings[i].height
    buildings[i].x = -6000 + spacing
 
-   spacing = spacing + (@cint)(buildings[i].width // 1)
+   spacing = spacing + buildings[i].width // 1
 
-   buildColors[i] = (@Color){(@cuchar)(Raylib.GetRandomValue(200, 240)), (@cuchar)(Raylib.GetRandomValue(200, 240)), (@cuchar)(Raylib.GetRandomValue(200, 250)), (@cuchar)(255)}
+   buildColors[i] = {
+      (@uint8)(Raylib.GetRandomValue(200, 240)),
+      (@uint8)(Raylib.GetRandomValue(200, 240)),
+      (@uint8)(Raylib.GetRandomValue(200, 250)), 
+      255_u8}
 end
 
-local camera: Camera2D = {}
-camera.target = (@Vector2){ player.x + 20, player.y + 20 }
-camera.offset = (@Vector2){ screenWidth/2, screenHeight/2 }
-camera.rotation = 0_f32
-camera.zoom = 1_f32
+local camera: Camera2D = {
+   target = { player.x + 20, player.y + 20 },
+   offset = { screenWidth/2, screenHeight/2 },
+   rotation = 0,
+   zoom = 1
+}
 
 Raylib.SetTargetFPS(60) -- set our game to run at 60 frames-per-second
 
@@ -55,7 +60,7 @@ while not Raylib.WindowShouldClose() do
    end
 
    -- camera target follows player
-   camera.target = (@Vector2){ player.x + 20, player.y + 20 }
+   camera.target = { player.x + 20, player.y + 20 }
 
    -- camera rotation controls
    if Raylib.IsKeyDown(KeyboardKey.KEY_A) then
@@ -72,7 +77,7 @@ while not Raylib.WindowShouldClose() do
    end
 
    -- camera zoom controls
-   camera.zoom = camera.zoom + (@float32)(Raylib.GetMouseWheelMove() * 0.05_f32)
+   camera.zoom = camera.zoom + Raylib.GetMouseWheelMove() * 0.05
 
    if camera.zoom > 3 then
       camera.zoom = 3
@@ -101,8 +106,8 @@ while not Raylib.WindowShouldClose() do
 
          Raylib.DrawRectangleRec(player, RaylibColors.Red)
 
-         Raylib.DrawLine((@cint)(camera.target.x), (@cint)(-screenHeight * 10), (@cint)(camera.target.x), (@cint)(screenHeight * 10), RaylibColors.Green)
-         Raylib.DrawLine((@cint)(-screenWidth * 10), (@cint)(camera.target.y), (@cint)(screenWidth * 10), (@cint)(camera.target.y), RaylibColors.Green)
+         Raylib.DrawLine(camera.target.x, -screenHeight * 10, camera.target.x, screenHeight * 10, RaylibColors.Green)
+         Raylib.DrawLine(-screenWidth * 10, camera.target.y, screenWidth * 10, camera.target.y, RaylibColors.Green)
 
       Raylib.EndMode2D()
 

--- a/raylib.nelua
+++ b/raylib.nelua
@@ -43,7 +43,7 @@ global Matrix     <cimport, nodecl> = @record{                                  
    m2: float32, m6: float32, m10: float32, m14: float32,
    m3: float32, m7: float32, m11: float32, m15: float32
 }
-global Color     <cimport, nodecl> = @record{r: cuchar, g: cuchar, b: cuchar, a: cuchar}              -- Color type, RGBA (32bit)
+global Color     <cimport, nodecl> = @record{r: uint8, g: uint8, b: uint8, a: uint8}              -- Color type, RGBA (32bit)
 global Rectangle <cimport, nodecl> = @record{x: float32, y: float32, width: float32, height: float32} -- Rectangle type
 
 -- Image type, bpp always RGBA (32bit)
@@ -1158,7 +1158,7 @@ local function CheckCollisionPointTriangle(point: Vector2, p1: Vector2, p2: Vect
 -- Basic shapes drawing functions
 function Raylib.DrawPixel(posX: cint, posY: cint, color: Color)                                                                                            <inline>        DrawPixel(posX, posY, color)                                                           end
 function Raylib.DrawPixelV(position: Vector2, color: Color)                                                                                                <inline>        DrawPixelV(position, color)                                                            end
-function Raylib.DrawLine(startPosX: cint, startPosY: cint, endPosX: cint, endPosY: cint, color: Color)                                                     <inline>        DrawLine(startPosX, startPosY, endPosX, endPosY, color)                                end
+function Raylib.DrawLine(startPosX: cint <autocast>, startPosY: cint <autocast>, endPosX: cint <autocast>, endPosY: cint <autocast>, color: Color)                                                     <inline>        DrawLine(startPosX, startPosY, endPosX, endPosY, color)                                end
 function Raylib.DrawLineV(startPos: Vector2, endPos: Vector2, color: Color)                                                                                <inline>        DrawLineV(startPos, endPos, color)                                                     end
 function Raylib.DrawLineEx(startPos: Vector2, endPos: Vector2, thick: float32, color: Color)                                                               <inline>        DrawLineEx(startPos, endPos, thick, color)                                             end
 function Raylib.DrawLineBezier(startPos: Vector2, endPos: Vector2, thick: float32, color: Color)                                                           <inline>        DrawLineBezier(startPos, endPos, thick, color)                                         end


### PR DESCRIPTION
This can be controversial, but I think it's more luaish to not do
type casting or use type literals when possible

1. Recently in Nelua casting can be hidden from function
calls using `<autocast>` in the function arguments, I think this can work
well for binders too

2. Explicit casting can me omitted in typed variables

3. Casting in number expressions can be omitted when doing it with the
right types